### PR TITLE
Trigger lco event problem

### DIFF
--- a/opencl/buffer.cpp
+++ b/opencl/buffer.cpp
@@ -43,9 +43,6 @@ buffer::enqueue_send_impl(
     
     // send command to server class
     typedef hpx::opencl::server::buffer::enqueue_send_action func;
-    std::stringstream str;
-    str << "enqueue_send" << std::endl;
-    std::cout << str.str() << std::flush;
     hpx::apply<func>( this->get_gid(),
                       dst.get_gid(),
                       src_event.get_event_id(),
@@ -55,7 +52,6 @@ buffer::enqueue_send_impl(
                       size,
                       dependencies.event_ids,
                       dependencies.device_ids ); 
-
 
     // return futures
     return send_result( std::move(src_event.get_future()),

--- a/opencl/buffer.cpp
+++ b/opencl/buffer.cpp
@@ -43,6 +43,9 @@ buffer::enqueue_send_impl(
     
     // send command to server class
     typedef hpx::opencl::server::buffer::enqueue_send_action func;
+    std::stringstream str;
+    str << "enqueue_send" << std::endl;
+    std::cout << str.str() << std::flush;
     hpx::apply<func>( this->get_gid(),
                       dst.get_gid(),
                       src_event.get_event_id(),
@@ -52,6 +55,7 @@ buffer::enqueue_send_impl(
                       size,
                       dependencies.event_ids,
                       dependencies.device_ids ); 
+
 
     // return futures
     return send_result( std::move(src_event.get_future()),

--- a/opencl/fwd_declarations.hpp
+++ b/opencl/fwd_declarations.hpp
@@ -11,7 +11,7 @@
 // This file forward-declares all hpxcl classes.
 // This is important to remove circular dependencies and improve compile speed.
 
-
+#include "export_definitions.hpp"
 
 namespace hpx {
 
@@ -25,11 +25,11 @@ namespace opencl {
 
     // The OpenCL server namespace
     namespace server {
-        
-        class device;
-        class buffer;
-        class program;
-        class kernel;
+
+        class HPX_OPENCL_EXPORT device;
+        class HPX_OPENCL_EXPORT buffer;
+        class HPX_OPENCL_EXPORT program;
+        class HPX_OPENCL_EXPORT kernel;
 
     }
 

--- a/opencl/lcos/event.cpp
+++ b/opencl/lcos/event.cpp
@@ -23,7 +23,7 @@ void hpx::opencl::lcos::detail::event<void, hpx::util::unused_type>::arm(){
     // Tell the device server that we'd like to be informed when the cl_event
     // is completed
     typedef hpx::opencl::server::device::activate_deferred_event_action func;
-    hpx::apply<func>(device_id, this->get_event_id());
+    hpx::apply<func>(device_id, event_id);
 
 }
 

--- a/opencl/lcos/event.hpp
+++ b/opencl/lcos/event.hpp
@@ -229,10 +229,6 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
         virtual
         ~event()
         {
-                std::stringstream str;
-                str << "delete <void> " << this->get_base_gid() << std::endl;
-                std::cout << str.str() << std::flush;
-
             unregister_event( device_id,
                               this->get_base_gid() );
         }
@@ -327,9 +323,6 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
         {
             boost::unique_lock<naming::gid_type> l(this->gid_.get_mutex());
             long counter = --this->count_;
-                std::stringstream str;
-                str << "requires_delete(" << counter << ") " << event_id << " " << naming::detail::has_credits(this->gid_) << std::endl;
-                std::cout << str.str() << std::flush;
 
             // special case: counter == 1. (meaning: agas is the only one
             // still holding a reference to this object. especially,

--- a/opencl/lcos/event.hpp
+++ b/opencl/lcos/event.hpp
@@ -12,6 +12,7 @@
 
 #include <hpx/lcos/promise.hpp>
 
+#include "../export_definitions.hpp"
 #include "zerocopy_buffer.hpp"
 
 namespace hpx { namespace opencl { namespace lcos
@@ -27,7 +28,7 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
     template <typename Result, typename RemoteResult>
     class event;
 }}}}
- 
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components { namespace detail
 {
@@ -47,7 +48,7 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
 
-    void unregister_event( hpx::naming::id_type device_id,
+    HPX_OPENCL_EXPORT void unregister_event( hpx::naming::id_type device_id,
                            hpx::naming::gid_type event_gid );
 
     //////////////////////////////////////////////////////////////////////////
@@ -98,7 +99,7 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
             &set_zerocopy_data<T>,
             set_zerocopy_data_action<T> >
     {};
- 
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Result, typename RemoteResult>
     class event
@@ -108,10 +109,10 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
     private:
         typedef hpx::lcos::detail::promise<Result, RemoteResult> parent_type;
         typedef typename hpx::lcos::detail::future_data<Result>::data_type
-            data_type; 
+            data_type;
 
     public:
-       
+
         event(hpx::naming::id_type && device_id_, Result && result_buffer_)
             : device_id(std::move(device_id_)),
               result_buffer(std::move(result_buffer_))
@@ -121,7 +122,7 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
         virtual
         ~event()
         {
-            unregister_event( device_id, 
+            unregister_event( device_id,
                               this->get_base_gid() );
         }
 
@@ -133,7 +134,7 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
         // This holds the buffer that will get returned by the future.
         Result result_buffer;
 
-        
+
         ////////////////////////////////////////////////////////////////////////
         // Internal stuff
         //
@@ -215,11 +216,11 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
     private:
         typedef hpx::lcos::detail::promise<void, hpx::util::unused_type>
             parent_type;
-        typedef typename hpx::lcos::detail::future_data<void>::data_type
-            data_type; 
+        typedef hpx::lcos::detail::future_data<void>::data_type
+            data_type;
 
     public:
-       
+
         event(hpx::naming::id_type && device_id_)
             : device_id(std::move(device_id_)), is_armed(false)
         {
@@ -231,8 +232,8 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
                 std::stringstream str;
                 str << "delete <void> " << this->get_base_gid() << std::endl;
                 std::cout << str.str() << std::flush;
-            
-            unregister_event( device_id, 
+
+            unregister_event( device_id,
                               this->get_base_gid() );
         }
 
@@ -242,13 +243,13 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
     private:
         boost::atomic<bool> is_armed;
 
-        void arm();
+        HPX_OPENCL_EXPORT void arm();
 
     public:
         // Gets called by when_all, wait_all, etc
         virtual void execute_deferred(error_code& ec = throws){
             if(!is_armed.exchange(true)){
-                this->arm(); 
+                this->arm();
             }
         }
 
@@ -275,7 +276,7 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
             else
                 return this->parent_type::wait_until(abs_time, ec);
         };
-        
+
         ////////////////////////////////////////////////////////////////////////
         // Internal stuff
         //

--- a/opencl/lcos/event.hpp
+++ b/opencl/lcos/event.hpp
@@ -193,6 +193,8 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
             {
                 HPX_ASSERT(event_id.get_gid() != naming::invalid_gid);
 
+                l.unlock();
+
                 // delete local reference to prevent recursive dependency
                 event_id = hpx::naming::id_type();
 
@@ -330,6 +332,8 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
             if (1 == counter)
             {
                 HPX_ASSERT(event_id.get_gid() != naming::invalid_gid);
+
+                l.unlock();
 
                 // delete local reference to prevent recursive dependency
                 event_id = hpx::naming::id_type();

--- a/opencl/lcos/event.hpp
+++ b/opencl/lcos/event.hpp
@@ -228,6 +228,10 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
         virtual
         ~event()
         {
+                std::stringstream str;
+                str << "delete <void> " << this->get_base_gid() << std::endl;
+                std::cout << str.str() << std::flush;
+            
             unregister_event( device_id, 
                               this->get_base_gid() );
         }
@@ -322,6 +326,9 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
         {
             boost::unique_lock<naming::gid_type> l(this->gid_.get_mutex());
             long counter = --this->count_;
+                std::stringstream str;
+                str << "requires_delete(" << counter << ") " << event_id << " " << naming::detail::has_credits(this->gid_) << std::endl;
+                std::cout << str.str() << std::flush;
 
             // special case: counter == 1. (meaning: agas is the only one
             // still holding a reference to this object. especially,
@@ -415,6 +422,7 @@ namespace hpx { namespace opencl { namespace lcos
         /// \brief Return the global id of this \a future instance
         naming::id_type get_gid() const
         {
+            HPX_ASSERT(false);
             return (*impl_)->get_gid();
         }
 
@@ -516,6 +524,7 @@ namespace hpx { namespace opencl { namespace lcos
         /// \brief Return the global id of this \a future instance
         naming::id_type get_gid() const
         {
+            HPX_ASSERT(false);
             return (*impl_)->get_gid();
         }
 

--- a/opencl/server/buffer.cpp
+++ b/opencl/server/buffer.cpp
@@ -30,7 +30,7 @@ static void buffer_cleanup(uintptr_t device_mem_ptr)
 {
     cl_int err;
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     cl_mem device_mem = reinterpret_cast<cl_mem>(device_mem_ptr);
 
@@ -63,7 +63,7 @@ buffer::init( hpx::naming::id_type device_id, cl_mem_flags flags,
                                               std::size_t size)
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     this->parent_device_id = std::move(device_id);
     this->parent_device = hpx::get_ptr
@@ -80,7 +80,7 @@ buffer::init( hpx::naming::id_type device_id, cl_mem_flags flags,
     cl_mem_flags modified_flags = flags &! (CL_MEM_USE_HOST_PTR
                                             | CL_MEM_ALLOC_HOST_PTR
                                             | CL_MEM_COPY_HOST_PTR);
-    
+
     // Create the Context
     device_mem = clCreateBuffer(context, modified_flags, size, NULL, &err);
     cl_ensure(err, "clCreateBuffer()");
@@ -92,7 +92,7 @@ std::size_t
 buffer::size()
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     std::size_t size;
     cl_int err;
@@ -112,8 +112,8 @@ buffer::enqueue_read( hpx::naming::id_type && event_gid,
                       std::size_t size,
                       std::vector<hpx::naming::id_type> && dependencies ){
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
-    
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
+
     typedef hpx::serialization::serialize_buffer<char> buffer_type;
 
     cl_int err;
@@ -158,8 +158,8 @@ buffer::send_bruteforce( hpx::naming::id_type && dst,
                          std::vector<hpx::naming::id_type> && dst_dependencies)
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
-    
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
+
     ////////////////////////////////////////////////////////////////////////////
     // Read
     //
@@ -214,8 +214,8 @@ buffer::send_direct( hpx::naming::id_type && dst,
                      std::vector<hpx::naming::id_type> && dst_dependencies)
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
-    
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
+
     cl_int err;
     cl_event return_event;
 

--- a/opencl/server/buffer.hpp
+++ b/opencl/server/buffer.hpp
@@ -26,7 +26,7 @@ namespace hpx { namespace opencl{ namespace server{
     // /////////////////////////////////////////////////////
     //  This class represents an opencl buffer.
 
-    class buffer
+    class HPX_OPENCL_EXPORT buffer
       : public hpx::components::managed_component_base<buffer>
     {
     public:
@@ -38,10 +38,10 @@ namespace hpx { namespace opencl{ namespace server{
 
         ///////////////////////////////////////////////////
         /// Local functions
-        /// 
+        ///
         void init(hpx::naming::id_type device_id, cl_mem_flags flags,
                                                   std::size_t size);
-        
+
         cl_mem get_cl_mem();
 
         //////////////////////////////////////////////////
@@ -203,8 +203,8 @@ hpx::opencl::server::buffer::enqueue_write(
                        std::size_t offset,
                        hpx::serialization::serialize_buffer<T> data,
                        std::vector<hpx::naming::id_type> && dependencies ){
-    
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     cl_int err;
     cl_event return_event;
@@ -238,8 +238,8 @@ hpx::opencl::server::buffer::enqueue_read_to_userbuffer_local(
                        std::size_t offset,
                        hpx::serialization::serialize_buffer<T> data,
                        std::vector<hpx::naming::id_type> && dependencies ){
-    
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     cl_int err;
     cl_event return_event;
@@ -277,7 +277,7 @@ hpx::opencl::server::buffer::enqueue_read_to_userbuffer_remote(
     std::uintptr_t remote_data_addr,
     std::vector<hpx::naming::id_type> && dependencies ){
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     typedef hpx::serialization::serialize_buffer<char> buffer_type;
 

--- a/opencl/server/device.cpp
+++ b/opencl/server/device.cpp
@@ -24,7 +24,7 @@ using namespace hpx::opencl::server;
 device::device()
 {
     // Register the event deletion callback function at the event map
-    event_map.register_deletion_callback(delete_event);
+    event_map.register_deletion_callback(&delete_event);
 }
 
 // External destructor.
@@ -33,7 +33,7 @@ static void device_cleanup(uintptr_t command_queue_ptr,
                            uintptr_t context_ptr)
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     cl_int err;
 
@@ -47,9 +47,9 @@ static void device_cleanup(uintptr_t command_queue_ptr,
         cl_ensure_nothrow(err, "clFinish()");
         err = clReleaseCommandQueue(command_queue);
         cl_ensure_nothrow(err, "clReleaseCommandQueue()");
-        command_queue = NULL; 
+        command_queue = NULL;
     }
-    
+
     // Release context
     if(context)
     {
@@ -80,19 +80,19 @@ void
 device::init(cl_device_id _device_id, bool enable_profiling)
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     this->device_id = _device_id;
 
     cl_int err;
-    
+
     // Retrieve platformID
     err = clGetDeviceInfo(this->device_id, CL_DEVICE_PLATFORM,
                           sizeof(platform_id), &platform_id, NULL);
     cl_ensure(err, "clGetDeviceInfo()");
 
     // Create Context
-    cl_context_properties context_properties[] = 
+    cl_context_properties context_properties[] =
                         {CL_CONTEXT_PLATFORM,
                          (cl_context_properties) platform_id,
                          0};
@@ -105,7 +105,7 @@ device::init(cl_device_id _device_id, bool enable_profiling)
     cl_ensure(err, "clCreateContext()");
 
     // Get supported device queue properties
-    hpx::serialization::serialize_buffer<char> supported_queue_properties_data = 
+    hpx::serialization::serialize_buffer<char> supported_queue_properties_data =
                                     get_device_info(CL_DEVICE_QUEUE_PROPERTIES);
     cl_command_queue_properties supported_queue_properties =
                 *( reinterpret_cast<cl_command_queue_properties *>(
@@ -142,8 +142,8 @@ device::init(cl_device_id _device_id, bool enable_profiling)
 hpx::serialization::serialize_buffer<char>
 device::get_device_info(cl_device_info info_type)
 {
-    
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     // Declairing the cl error code variable
     cl_int err;
@@ -169,8 +169,8 @@ device::get_device_info(cl_device_info info_type)
 hpx::serialization::serialize_buffer<char>
 device::get_platform_info(cl_platform_info info_type)
 {
-    
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     // Declairing the cl error code variable
     cl_int err;
@@ -218,19 +218,19 @@ hpx::id_type
 device::create_buffer( cl_mem_flags flags, std::size_t size )
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     // Create new buffer
     hpx::id_type buf = hpx::components::new_<hpx::opencl::server::buffer>
                                                      ( hpx::find_here() ).get();
 
     // Initialize buffer locally
-    boost::shared_ptr<hpx::opencl::server::buffer> buffer_server = 
+    boost::shared_ptr<hpx::opencl::server::buffer> buffer_server =
                         hpx::get_ptr<hpx::opencl::server::buffer>( buf ).get();
 
     buffer_server->init(get_gid(), flags, size);
 
-    return buf;           
+    return buf;
 }
 
 hpx::id_type
@@ -238,14 +238,14 @@ device::create_program_with_source(
     hpx::serialization::serialize_buffer<char> src )
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     // Create new program
     hpx::id_type prog = hpx::components::new_<hpx::opencl::server::program>
                                                      ( hpx::find_here() ).get();
 
     // Initialize buffer locally
-    boost::shared_ptr<hpx::opencl::server::program> program_server = 
+    boost::shared_ptr<hpx::opencl::server::program> program_server =
                         hpx::get_ptr<hpx::opencl::server::program>( prog ).get();
 
     program_server->init_with_source( get_gid(), src );
@@ -258,14 +258,14 @@ device::create_program_with_binary(
     hpx::serialization::serialize_buffer<char> binary )
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     // Create new program
     hpx::id_type prog = hpx::components::new_<hpx::opencl::server::program>
                                                      ( hpx::find_here() ).get();
 
     // Initialize buffer locally
-    boost::shared_ptr<hpx::opencl::server::program> program_server = 
+    boost::shared_ptr<hpx::opencl::server::program> program_server =
                         hpx::get_ptr<hpx::opencl::server::program>( prog ).get();
 
     program_server->init_with_binary( get_gid(), binary );
@@ -276,7 +276,7 @@ device::create_program_with_binary(
 void
 device::release_event(hpx::naming::gid_type gid)
 {
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     // release data registered on event
     delete_event_data(event_map.get(gid));
@@ -291,7 +291,7 @@ void
 device::delete_event( cl_event event )
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     // delete the actual cl_event object
     cl_int err;
@@ -305,7 +305,7 @@ device::register_event( const hpx::naming::id_type & gid, cl_event event )
 {
 
     // Add pair to event_map
-    event_map.add(gid, event); 
+    event_map.add(gid, event);
 
 }
 
@@ -336,7 +336,7 @@ device::get_kernel_command_queue()
 {
     return command_queue;
 }
-    
+
 
 
 struct wait_for_cl_event_args{
@@ -359,7 +359,7 @@ wait_for_cl_event_callback( cl_event event, cl_int exec_status, void* user_data 
 void
 device::wait_for_cl_event(cl_event event)
 {
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     cl_int err;
 
@@ -376,7 +376,7 @@ device::wait_for_cl_event(cl_event event)
 
     // Attach callback
     err = clSetEventCallback(event, CL_COMPLETE, wait_for_cl_event_callback,
-                             &args); 
+                             &args);
     cl_ensure(err, "clSetEventCallback()");
 
     // Wait for the event to complete
@@ -389,10 +389,10 @@ void
 device::delete_event_data(cl_event event)
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     cl_int err;
-    
+
     // return if no data is registered
     if(!event_data_map.has_data(event))
         return;

--- a/opencl/server/device.cpp
+++ b/opencl/server/device.cpp
@@ -416,7 +416,7 @@ device::activate_deferred_event(hpx::naming::id_type event_id)
     wait_for_cl_event(event);
 
     // trigger the client event
-    hpx::trigger_lco_event(event_id);
+    hpx::trigger_lco_event(event_id, false);
 
         {
             std::stringstream str;

--- a/opencl/server/device.cpp
+++ b/opencl/server/device.cpp
@@ -417,6 +417,12 @@ device::activate_deferred_event(hpx::naming::id_type event_id)
 
     // trigger the client event
     hpx::trigger_lco_event(event_id);
+
+        {
+            std::stringstream str;
+            str << "trigger_lco_event " << event_id << std::endl;
+            std::cout << str.str() << std::flush;
+        }
 }
 
 void

--- a/opencl/server/device.cpp
+++ b/opencl/server/device.cpp
@@ -418,11 +418,6 @@ device::activate_deferred_event(hpx::naming::id_type event_id)
     // trigger the client event
     hpx::trigger_lco_event(event_id, false);
 
-        {
-            std::stringstream str;
-            str << "trigger_lco_event " << event_id << std::endl;
-            std::cout << str.str() << std::flush;
-        }
 }
 
 void

--- a/opencl/server/device.hpp
+++ b/opencl/server/device.hpp
@@ -10,6 +10,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/config.hpp>
 
+#include "../export_definitions.hpp"
 #include "../cl_headers.hpp"
 
 #include "util/event_map.hpp"
@@ -20,12 +21,12 @@
 
 ////////////////////////////////////////////////////////////////
 namespace hpx { namespace opencl{ namespace server{
-    
+
 
     // /////////////////////////////////////////////////////
     // This class represents an OpenCL accelerator device.
     //
-    class device
+    class HPX_OPENCL_EXPORT device
       : public hpx::components::managed_component_base<device>
     {
         typedef hpx::lcos::local::spinlock lock_type;
@@ -51,7 +52,7 @@ namespace hpx { namespace opencl{ namespace server{
         // returns device specific information
         hpx::serialization::serialize_buffer<char>
         get_device_info(cl_device_info info_type);
-        
+
         // returns platform specific information
         hpx::serialization::serialize_buffer<char>
         get_platform_info(cl_platform_info info_type);
@@ -70,7 +71,7 @@ namespace hpx { namespace opencl{ namespace server{
 
         /////////////////////////////////////////////////
         /// Behind-the-scenes functionality of this component
-        /// 
+        ///
 
         // releases an event registered to a GID
         void
@@ -79,7 +80,7 @@ namespace hpx { namespace opencl{ namespace server{
         // activates a deferred event
         void
         activate_deferred_event(hpx::naming::id_type);
-     
+
         // activates a deferred event<serialize_buffer<char> >
         void
         activate_deferred_event_with_data(hpx::naming::id_type);
@@ -109,7 +110,7 @@ namespace hpx { namespace opencl{ namespace server{
         cl_command_queue get_write_command_queue();
         cl_command_queue get_kernel_command_queue();
 
-        // event data handling. needed to keep clEnqueue* data alive 
+        // event data handling. needed to keep clEnqueue* data alive
         // (like clEnqueueWriteBuffer)
         template<typename T>
         void put_event_data( cl_event event,
@@ -126,7 +127,7 @@ namespace hpx { namespace opencl{ namespace server{
         ///////////////////////////////////////////////
         // Private Member Functions
         //
-        
+
         // Error Callback
         static void CL_CALLBACK error_callback(const char*, const void*,
                                                std::size_t, void*);
@@ -148,7 +149,7 @@ namespace hpx { namespace opencl{ namespace server{
 
         util::event_map     event_map;
         util::data_map      event_data_map;
-        
+
     };
 }}}
 

--- a/opencl/server/kernel.cpp
+++ b/opencl/server/kernel.cpp
@@ -32,7 +32,7 @@ static void kernel_cleanup(uintptr_t kernel_id_ptr)
 
     cl_int err;
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     cl_kernel kernel_id = reinterpret_cast<cl_kernel>(kernel_id_ptr);
 
@@ -65,7 +65,7 @@ kernel::init( hpx::naming::id_type device_id, cl_program program,
               std::string kernel_name )
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     this->parent_device_id = std::move(device_id);
     this->parent_device = hpx::get_ptr
@@ -86,7 +86,7 @@ void
 kernel::set_arg(cl_uint arg_index, hpx::naming::id_type buffer_id)
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
     cl_int err;
 
     // Get direct pointer to buffer
@@ -106,8 +106,8 @@ kernel::enqueue( hpx::naming::id_type && event_gid,
                  std::vector<std::size_t> size_vec,
                  std::vector<hpx::naming::id_type> && dependencies )
 {
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
-    
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
+
     cl_int err;
     cl_event return_event;
 
@@ -144,4 +144,4 @@ kernel::enqueue( hpx::naming::id_type && event_gid,
     parent_device->register_event(event_gid, return_event);
 
 }
-    
+

--- a/opencl/server/kernel.hpp
+++ b/opencl/server/kernel.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace opencl{ namespace server{
     // /////////////////////////////////////////////////////
     //  This class represents an opencl kernel.
 
-    class kernel
+    class HPX_OPENCL_EXPORT kernel
       : public hpx::components::managed_component_base<kernel>
     {
     public:
@@ -35,17 +35,17 @@ namespace hpx { namespace opencl{ namespace server{
 
         ///////////////////////////////////////////////////
         /// Local functions
-        /// 
+        ///
         void init ( hpx::naming::id_type device_id, cl_program program,
                     std::string kernel_name );
 
         //////////////////////////////////////////////////
         /// Exposed functionality of this component
         ///
-        
+
         // Sets an argument of the kernel
         void set_arg(cl_uint arg_index, hpx::naming::id_type buffer);
-       
+
         // Runs the kernel
         void enqueue( hpx::naming::id_type && event_gid,
                       std::vector<std::size_t> size,

--- a/opencl/server/program.cpp
+++ b/opencl/server/program.cpp
@@ -31,7 +31,7 @@ static void program_cleanup(uintptr_t program_id_ptr)
 
     cl_int err;
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     cl_program program_id = reinterpret_cast<cl_program>(program_id_ptr);
 
@@ -60,11 +60,11 @@ program::~program()
 
 
 void
-program::init_with_source( hpx::naming::id_type device_id, 
+program::init_with_source( hpx::naming::id_type device_id,
                            hpx::serialization::serialize_buffer<char> src )
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     this->parent_device_id = std::move(device_id);
     this->parent_device = hpx::get_ptr
@@ -93,13 +93,13 @@ program::init_with_source( hpx::naming::id_type device_id,
     cl_ensure(err, "clCreateProgramWithSource()");
 
 }
-        
+
 void
 program::init_with_binary( hpx::naming::id_type device_id,
                            hpx::serialization::serialize_buffer<char> binary )
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     this->parent_device_id = std::move(device_id);
     this->parent_device = hpx::get_ptr
@@ -138,7 +138,7 @@ program::acquire_build_log()
     // Query size
     err = clGetProgramBuildInfo(program_id, parent_device->get_device_id(),
                                 CL_PROGRAM_BUILD_LOG, 0, NULL, &build_log_size);
-   
+
     // Create buffer
     std::vector<char> buf(build_log_size);
 
@@ -158,7 +158,7 @@ program::acquire_build_log()
     sstream << "/// OPENCL BUILD LOG END" << std::endl;
     sstream << "//////////////////////////////////////" << std::endl;
     sstream << std::endl;
-    
+
     // return the nice looking error string.
     return sstream.str();
 
@@ -167,7 +167,7 @@ program::acquire_build_log()
 void
 program::throw_on_build_errors(const char* function_name){
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     cl_int err;
     cl_build_status build_status;
@@ -207,7 +207,7 @@ build_callback( cl_program program_id, void* user_data )
 void
 program::build(std::string options)
 {
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     cl_int err;
 
@@ -218,7 +218,7 @@ program::build(std::string options)
     hpx::lcos::local::promise<void> promise;
 
     // Retrieve the future
-    hpx::future<void> future = promise.get_future(); 
+    hpx::future<void> future = promise.get_future();
 
     // Create args for build_callback
     build_callback_args args;
@@ -237,7 +237,7 @@ program::build(std::string options)
     // Wait for compilation to finish
     future.wait();
 
-    // check build status 
+    // check build status
     throw_on_build_errors("clBuildProgram()");
 
 }
@@ -245,7 +245,7 @@ program::build(std::string options)
 hpx::serialization::serialize_buffer<char>
 program::get_binary()
 {
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     typedef hpx::serialization::serialize_buffer<char> buffer_type;
     cl_int err;
@@ -255,7 +255,7 @@ program::get_binary()
     err = clGetProgramInfo(program_id, CL_PROGRAM_NUM_DEVICES, sizeof(cl_uint),
                            &num_devices, NULL);
     cl_ensure(err, "clGetProgramInfo()");
-    
+
     // ensure that only one device is associated
     if(num_devices != 1)
     {
@@ -295,7 +295,7 @@ hpx::naming::id_type
 program::create_kernel(std::string kernel_name)
 {
 
-    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack()); 
+    HPX_ASSERT(hpx::opencl::tools::runs_on_large_stack());
 
     // Create new kernel
     hpx::id_type kernel = hpx::components::new_<hpx::opencl::server::kernel>

--- a/opencl/server/program.hpp
+++ b/opencl/server/program.hpp
@@ -23,7 +23,7 @@ namespace hpx { namespace opencl{ namespace server{
     // /////////////////////////////////////////////////////
     //  This class represents an opencl program.
 
-    class program
+    class HPX_OPENCL_EXPORT program
       : public hpx::components::managed_component_base<program>
     {
     public:
@@ -35,7 +35,7 @@ namespace hpx { namespace opencl{ namespace server{
 
         ///////////////////////////////////////////////////
         /// Local functions
-        /// 
+        ///
         void init_with_source( hpx::naming::id_type device_id,
                                hpx::serialization::serialize_buffer<char> src);
         void init_with_binary( hpx::naming::id_type device_id,

--- a/opencl/server/util/data_map.hpp
+++ b/opencl/server/util/data_map.hpp
@@ -27,7 +27,7 @@ namespace hpx { namespace opencl{ namespace server{ namespace util{
         send_to_client_impl( hpx::serialization::serialize_buffer<T, Alloc> data,
                              const hpx::naming::id_type& event_id )
         {
-            hpx::set_lco_value(event_id, data); 
+            hpx::set_lco_value(event_id, data, false); 
         }
 
     public:

--- a/opencl/server/util/event_map.cpp
+++ b/opencl/server/util/event_map.cpp
@@ -25,6 +25,11 @@ event_map::add(const hpx::naming::id_type & gid, cl_event event){
     hpx::naming::gid_type key = gid.get_gid();
 
     {
+        std::stringstream str;
+        str << "add  " << gid << std::endl;
+        std::cout << str.str() << std::flush;
+    }
+    {
         // Lock
         lock_type::scoped_lock l(lock);
         
@@ -53,7 +58,11 @@ event_map::get(const hpx::naming::id_type& id)
 
 cl_event
 event_map::get(const hpx::naming::gid_type& key){
-
+    {
+        std::stringstream str;
+        str << "get " << key << std::endl;
+        std::cout << str.str() << std::flush;
+    }
     cl_event result = NULL;
     {
         map_type::iterator it;
@@ -73,6 +82,12 @@ event_map::get(const hpx::naming::gid_type& key){
     // Return if event found
     if(result) return result;
 
+    {
+        std::stringstream str;
+        str << "get2 " << key << std::endl;
+        std::cout << str.str() << std::flush;
+    }
+
     // On failure, try again and register callback
     waitmap_type::value_type waits_entry(key, std::make_shared<condition_type>());
     {
@@ -89,6 +104,12 @@ event_map::get(const hpx::naming::gid_type& key){
             return it->second;
         }
 
+        {
+            std::stringstream str;
+            str << "wait " << key << std::endl;
+            std::cout << str.str() << std::flush;
+        }
+
         // On failure, register condition variable (or retrieve existing one)
         auto inserted_condvar = waits.insert(std::move(waits_entry));
         
@@ -103,6 +124,12 @@ event_map::get(const hpx::naming::gid_type& key){
         it = events.find(key);
         HPX_ASSERT(it != events.end());
 
+        {
+            std::stringstream str;
+            str << "wait_done " << key << std::endl;
+            std::cout << str.str() << std::flush;
+        }
+
         return it->second;
 
     }
@@ -112,6 +139,11 @@ event_map::get(const hpx::naming::gid_type& key){
 void 
 event_map::remove(const hpx::naming::gid_type &gid)
 {
+    {
+        std::stringstream str;
+        str << "rem " << gid << std::endl;
+        std::cout << str.str() << std::flush;
+    }
     cl_event event;
     {
         // Lock
@@ -125,15 +157,30 @@ event_map::remove(const hpx::naming::gid_type &gid)
         event = it->second;
     }
 
+    {
+        std::stringstream str;
+        str << "rem2 " << gid << std::endl;
+        std::cout << str.str() << std::flush;
+    }
     // run deletion callback
     deletion_callback(event);
 
+    {
+        std::stringstream str;
+        str << "rem3 " << gid << std::endl;
+        std::cout << str.str() << std::flush;
+    }
     {
         // Lock
         lock_type::scoped_lock l(lock);
     
         // Remove element
         events.erase(gid);
+    }
+    {
+        std::stringstream str;
+        str << "rem4 " << gid << std::endl;
+        std::cout << str.str() << std::flush;
     }
 }
 

--- a/opencl/server/util/event_map.cpp
+++ b/opencl/server/util/event_map.cpp
@@ -25,11 +25,6 @@ event_map::add(const hpx::naming::id_type & gid, cl_event event){
     hpx::naming::gid_type key = gid.get_gid();
 
     {
-        std::stringstream str;
-        str << "add  " << gid << std::endl;
-        std::cout << str.str() << std::flush;
-    }
-    {
         // Lock
         lock_type::scoped_lock l(lock);
         
@@ -58,11 +53,7 @@ event_map::get(const hpx::naming::id_type& id)
 
 cl_event
 event_map::get(const hpx::naming::gid_type& key){
-    {
-        std::stringstream str;
-        str << "get " << key << std::endl;
-        std::cout << str.str() << std::flush;
-    }
+
     cl_event result = NULL;
     {
         map_type::iterator it;
@@ -82,12 +73,6 @@ event_map::get(const hpx::naming::gid_type& key){
     // Return if event found
     if(result) return result;
 
-    {
-        std::stringstream str;
-        str << "get2 " << key << std::endl;
-        std::cout << str.str() << std::flush;
-    }
-
     // On failure, try again and register callback
     waitmap_type::value_type waits_entry(key, std::make_shared<condition_type>());
     {
@@ -104,12 +89,6 @@ event_map::get(const hpx::naming::gid_type& key){
             return it->second;
         }
 
-        {
-            std::stringstream str;
-            str << "wait " << key << std::endl;
-            std::cout << str.str() << std::flush;
-        }
-
         // On failure, register condition variable (or retrieve existing one)
         auto inserted_condvar = waits.insert(std::move(waits_entry));
         
@@ -124,12 +103,6 @@ event_map::get(const hpx::naming::gid_type& key){
         it = events.find(key);
         HPX_ASSERT(it != events.end());
 
-        {
-            std::stringstream str;
-            str << "wait_done " << key << std::endl;
-            std::cout << str.str() << std::flush;
-        }
-
         return it->second;
 
     }
@@ -139,11 +112,7 @@ event_map::get(const hpx::naming::gid_type& key){
 void 
 event_map::remove(const hpx::naming::gid_type &gid)
 {
-    {
-        std::stringstream str;
-        str << "rem " << gid << std::endl;
-        std::cout << str.str() << std::flush;
-    }
+
     cl_event event;
     {
         // Lock
@@ -157,19 +126,9 @@ event_map::remove(const hpx::naming::gid_type &gid)
         event = it->second;
     }
 
-    {
-        std::stringstream str;
-        str << "rem2 " << gid << std::endl;
-        std::cout << str.str() << std::flush;
-    }
     // run deletion callback
     deletion_callback(event);
 
-    {
-        std::stringstream str;
-        str << "rem3 " << gid << std::endl;
-        std::cout << str.str() << std::flush;
-    }
     {
         // Lock
         lock_type::scoped_lock l(lock);
@@ -177,11 +136,7 @@ event_map::remove(const hpx::naming::gid_type &gid)
         // Remove element
         events.erase(gid);
     }
-    {
-        std::stringstream str;
-        str << "rem4 " << gid << std::endl;
-        std::cout << str.str() << std::flush;
-    }
+
 }
 
 void

--- a/opencl/tools.hpp
+++ b/opencl/tools.hpp
@@ -13,6 +13,7 @@
 
 #include <sstream>
 
+#include "export_definitions.hpp"
 #include "cl_headers.hpp"
 
 #ifndef CL_VERSION_1_1
@@ -43,7 +44,7 @@ namespace hpx { namespace opencl { namespace tools {
                                 errorMessage.str());                   \
         }                                                              \
     }
-    
+
      // To be called on OpenCL errorcodes in destructors, does not throw
     #define cl_ensure_nothrow(errCode, functionname){                  \
         if(errCode != CL_SUCCESS)                                      \
@@ -56,10 +57,10 @@ namespace hpx { namespace opencl { namespace tools {
                       << hpx::endl;                                    \
         }                                                              \
     }
-    
-    
+
+
     // Translates CL errorcode to descriptive string
-    const char* cl_err_to_str(cl_int errCode);
+    HPX_OPENCL_EXPORT const char* cl_err_to_str(cl_int errCode);
 
     // Returns true if curren thread runs on a large stack
     bool runs_on_large_stack();

--- a/opencl/util/enqueue_overloads.hpp
+++ b/opencl/util/enqueue_overloads.hpp
@@ -15,7 +15,7 @@
 #include "../lcos/event.hpp"
 
 namespace hpx{ namespace opencl{ namespace util{
-    
+
     struct resolved_events{
         public:
             std::vector<hpx::naming::id_type> event_ids;
@@ -40,7 +40,7 @@ namespace hpx{ namespace opencl{ namespace util{
             }
     };
 
-    
+
 
 }}}
 
@@ -56,12 +56,12 @@ namespace hpx{ namespace opencl{ namespace util{ namespace enqueue_overloads{
             result_type;
         typedef typename hpx::opencl::lcos::event<result_type>::wrapped_type
             event_type;
-        
+
         auto shared_state = hpx::lcos::detail::get_shared_state(fut);
         auto ev = boost::static_pointer_cast<event_type>(shared_state);
 
         device_id = ev->get_device_gid();
-        
+
         auto event_id = ev->get_event_id();
         return event_id;
     }
@@ -102,7 +102,7 @@ namespace hpx{ namespace opencl{ namespace util{ namespace enqueue_overloads{
     {
         template<typename T>
         void
-        operator()(const T & t, 
+        operator()(const T & t,
                    std::vector<hpx::naming::id_type> &event_ids,
                    std::vector<hpx::naming::gid_type> &device_ids){
             hpx::naming::gid_type device_id;
@@ -138,7 +138,7 @@ namespace hpx{ namespace opencl{ namespace util{ namespace enqueue_overloads{
     template<typename Dep>
     void
     resolver_impl(std::vector<hpx::naming::id_type>& event_ids,
-                  std::vector<hpx::naming::gid_type>& device_ids,    
+                  std::vector<hpx::naming::gid_type>& device_ids,
                   Dep&& dep){
         extrude_all_ids<detail::is_container<Dep>::value>()( dep, event_ids,
                                                                   device_ids);
@@ -147,7 +147,7 @@ namespace hpx{ namespace opencl{ namespace util{ namespace enqueue_overloads{
     template<typename Dep, typename ...Deps>
     void
     resolver_impl(std::vector<hpx::naming::id_type>& event_ids,
-                  std::vector<hpx::naming::gid_type>& device_ids,    
+                  std::vector<hpx::naming::gid_type>& device_ids,
                   Dep&& dep, Deps&&... deps){
 
         // process current dep
@@ -172,10 +172,10 @@ namespace hpx{ namespace opencl{ namespace util{ namespace enqueue_overloads{
 }}}}
 
 
-#define HPX_OPENCL_GENERATE_ENQUEUE_OVERLOADS(return_value, name, args...)      \
+#define HPX_OPENCL_GENERATE_ENQUEUE_OVERLOADS(return_value, name, ...)          \
                                                                                 \
     return_value                                                                \
-    name##_impl(args, hpx::opencl::util::resolved_events &&);                   \
+    name##_impl(__VA_ARGS__, hpx::opencl::util::resolved_events &&);            \
                                                                                 \
     /*                                                                          \
      * This class  splits the arguments from the dependencies.                  \
@@ -199,7 +199,7 @@ namespace hpx{ namespace opencl{ namespace util{ namespace enqueue_overloads{
     return_value                                                                \
     name (Params &&... params)                                                  \
     {                                                                           \
-        return name##_caller<args>()(this, std::forward<Params>(params)...);    \
+        return name##_caller<__VA_ARGS__>()(this, std::forward<Params>(params)...); \
     }
 
 

--- a/tests/performance/opencl/CMakeLists.txt
+++ b/tests/performance/opencl/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 set(tests
     bandwith
+    deadlock
    )
 
 

--- a/tests/performance/opencl/bandwith.cpp
+++ b/tests/performance/opencl/bandwith.cpp
@@ -146,52 +146,18 @@ static void run_hpxcl_send_test( hpx::opencl::device device1,
         fut.wait();
  
         // RUN!
-            {
-                std::stringstream str;
-                str << "before sleep" << std::endl;
-                std::cout << str.str() << std::flush;
-            }
-            hpx::this_thread::sleep_for(boost::chrono::milliseconds(10));
-            {
-                std::stringstream str;
-                str << "after sleep" << std::endl;
-                std::cout << str.str() << std::flush;
-            }
         hpx::util::high_resolution_timer walltime;
         for(std::size_t it = 0; it < num_iterations; it ++)
         {
-            hpx::this_thread::sleep_for(boost::chrono::milliseconds(10));
-            {
-                std::stringstream str;
-                str << "before enqueue_send1" << std::endl;
-                std::cout << str.str() << std::flush;
-            }
             // Copy from buffer1 to buffer2
             auto send_result =
                 buffer1.enqueue_send(buffer2, 0, 0, test_data.size(), fut);
-            {
-                std::stringstream str;
-                str << "after enqueue_send1" << std::endl;
-                std::cout << str.str() << std::flush;
-            }
 
-
-            hpx::this_thread::sleep_for(boost::chrono::milliseconds(10));
-            {
-                std::stringstream str;
-                str << "before enqueue_send2" << std::endl;
-                std::cout << str.str() << std::flush;
-            }
             // Copy from buffer2 to buffer1
             auto send_result2 = 
                 buffer2.enqueue_send(buffer1, 0, 0, test_data.size(),
                                      send_result.dst_future);
             fut = std::move(send_result2.dst_future);
-            {
-                std::stringstream str;
-                str << "after enqueue_send2" << std::endl;
-                std::cout << str.str() << std::flush;
-            }
         }
 
         // wait for last send to finish
@@ -315,7 +281,7 @@ static void cl_test(hpx::opencl::device local_device,
 
 
     const std::size_t testdata_size = static_cast<std::size_t>(1) << 1;
-    num_iterations = 2;
+    num_iterations = 50;
 
     // Get localities
     hpx::naming::id_type remote_location =
@@ -336,7 +302,7 @@ static void cl_test(hpx::opencl::device local_device,
 
 
 
-/*    // Run local opencl test
+    // Run local opencl test
     run_opencl_local_test(local_device);
 
     // Run local hpxcl test
@@ -347,16 +313,16 @@ static void cl_test(hpx::opencl::device local_device,
 
     // Run hpx loopback test
     run_hpx_loopback_test(remote_location);
-*/
+
     // Run hpxcl send local-local test
     run_hpxcl_send_test(local_device, local_device);
-/*
+
     // Run hpxcl send remote-remote test
     run_hpxcl_send_test(remote_device, remote_device);
 
     // Run hpxcl send local-remote test
     run_hpxcl_send_test(local_device, remote_device);
-*/
+
 
     std::cout << results << std::endl;
 }

--- a/tests/performance/opencl/deadlock.cpp
+++ b/tests/performance/opencl/deadlock.cpp
@@ -1,0 +1,90 @@
+// Copyright (c)       2013 Martin Stumpf
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/hpx_main.hpp>
+
+#include "../../../opencl.hpp"
+
+static void register_event(hpx::opencl::device cldevice,
+                           const hpx::naming::id_type & event_id)
+{
+
+    boost::shared_ptr<hpx::opencl::server::device>
+    parent_device = hpx::get_ptr<hpx::opencl::server::device>
+                        (cldevice.get_gid()).get();
+
+    // create a fake event
+    cl_int err;
+    cl_event event_cl = clCreateUserEvent (
+            parent_device->get_context(),
+            &err);
+    cl_ensure(err, "clEnqueueWriteBuffer()");
+    err = clSetUserEventStatus(event_cl, CL_COMPLETE);
+    cl_ensure(err, "clSetUserEventStatus()");
+
+    parent_device->register_event(event_id, event_cl);
+}
+
+#define ATOMIC_PRINT( message )                                                 \
+{                                                                               \
+    std::stringstream str;                                                      \
+    str << "LOG: " << message << std::endl;                                     \
+    std::cout << str.str() << std::flush;                                       \
+}
+
+
+int main()
+{
+        typedef typename hpx::opencl::lcos::event<void>::wrapped_type
+            event_type;
+
+        auto devices = 
+            hpx::opencl::get_all_devices( CL_DEVICE_TYPE_ALL,
+                                          "OpenCL 1.1" ).get();
+        HPX_ASSERT(!devices.empty());
+        hpx::opencl::device device = devices[0];
+
+        hpx::shared_future<void> fut;
+        {
+            hpx::opencl::lcos::event<void> ev(device.get_gid());
+            register_event(device, ev.get_event_id());
+            fut = ev.get_future();
+        }
+
+        hpx::this_thread::sleep_for(boost::chrono::milliseconds(10));
+
+        {
+            auto shared_state = hpx::lcos::detail::get_shared_state(fut);
+            auto ev = boost::static_pointer_cast<event_type>(shared_state);
+            ATOMIC_PRINT("ev " << ev->get_event_id());
+        }
+
+    
+        hpx::this_thread::sleep_for(boost::chrono::milliseconds(10));
+
+        {
+            auto shared_state = hpx::lcos::detail::get_shared_state(fut);
+            auto ev = boost::static_pointer_cast<event_type>(shared_state);
+
+            ATOMIC_PRINT("trigger_lco_event_manually " << ev->get_event_id());
+            hpx::trigger_lco_event(ev->get_event_id());
+        }
+
+        ATOMIC_PRINT("before sleep");
+        hpx::this_thread::sleep_for(boost::chrono::milliseconds(10));
+        ATOMIC_PRINT("after sleep");
+        
+        {
+            auto shared_state = hpx::lcos::detail::get_shared_state(fut);
+            auto ev = boost::static_pointer_cast<event_type>(shared_state);
+            ATOMIC_PRINT("ev " << ev->get_event_id());
+        }
+
+    return 0;
+}
+
+
+

--- a/tests/performance/opencl/deadlock.cpp
+++ b/tests/performance/opencl/deadlock.cpp
@@ -38,10 +38,10 @@ static void register_event(hpx::opencl::device cldevice,
 
 int main()
 {
-        typedef typename hpx::opencl::lcos::event<void>::wrapped_type
+        typedef hpx::opencl::lcos::event<void>::wrapped_type
             event_type;
 
-        auto devices = 
+        auto devices =
             hpx::opencl::get_all_devices( CL_DEVICE_TYPE_ALL,
                                           "OpenCL 1.1" ).get();
         HPX_ASSERT(!devices.empty());
@@ -62,7 +62,7 @@ int main()
             ATOMIC_PRINT("ev " << ev->get_event_id());
         }
 
-    
+
         hpx::this_thread::sleep_for(boost::chrono::milliseconds(10));
 
         {
@@ -70,13 +70,13 @@ int main()
             auto ev = boost::static_pointer_cast<event_type>(shared_state);
 
             ATOMIC_PRINT("trigger_lco_event_manually " << ev->get_event_id());
-            hpx::trigger_lco_event(ev->get_event_id());
+            hpx::trigger_lco_event(ev->get_event_id(), false);
         }
 
         ATOMIC_PRINT("before sleep");
         hpx::this_thread::sleep_for(boost::chrono::milliseconds(10));
         ATOMIC_PRINT("after sleep");
-        
+
         {
             auto shared_state = hpx::lcos::detail::get_shared_state(fut);
             auto ev = boost::static_pointer_cast<event_type>(shared_state);

--- a/tests/performance/opencl/util/cl_tests.hpp
+++ b/tests/performance/opencl/util/cl_tests.hpp
@@ -100,7 +100,7 @@ static std::vector<hpx::opencl::device> init(variables_map & vm)
 
     // Try to get remote devices
     std::vector<hpx::opencl::device> remote_devices
-            = hpx::opencl::get_local_devices( CL_DEVICE_TYPE_ALL,
+            = hpx::opencl::get_remote_devices( CL_DEVICE_TYPE_ALL,
                                                "OpenCL 1.1" ).get();
     std::vector<hpx::opencl::device> local_devices
             = hpx::opencl::get_local_devices( CL_DEVICE_TYPE_ALL,

--- a/tests/performance/opencl/util/cl_tests.hpp
+++ b/tests/performance/opencl/util/cl_tests.hpp
@@ -100,7 +100,7 @@ static std::vector<hpx::opencl::device> init(variables_map & vm)
 
     // Try to get remote devices
     std::vector<hpx::opencl::device> remote_devices
-            = hpx::opencl::get_remote_devices( CL_DEVICE_TYPE_ALL,
+            = hpx::opencl::get_local_devices( CL_DEVICE_TYPE_ALL,
                                                "OpenCL 1.1" ).get();
     std::vector<hpx::opencl::device> local_devices
             = hpx::opencl::get_local_devices( CL_DEVICE_TYPE_ALL,

--- a/tests/unit/opencl/dynamic_overloads.cpp
+++ b/tests/unit/opencl/dynamic_overloads.cpp
@@ -28,7 +28,7 @@ static void cl_test( hpx::opencl::device local_device,
                      hpx::opencl::device cldevice ){
 
     hpx::opencl::lcos::event<void> event(cldevice.get_gid());
-    register_event(cldevice, event.get_gid());
+    register_event(cldevice, event.get_event_id());
 
     hpx::shared_future<void> sfut = event.get_future();
     std::vector<hpx::shared_future<void>> vsfut1 = {sfut};


### PR DESCRIPTION
This fixes the problem where set_lco_value and trigger_lco_event caused the event shared_state to get destroyed prematurely.
