### PR TITLE
Let `serialize_buffer` allocate memory

### DIFF
--- a/examples/opencl/benchmark_vector/hpxcl_single.hpp
+++ b/examples/opencl/benchmark_vector/hpxcl_single.hpp
@@ -242,8 +242,7 @@ hpxcl_single_calculate(hpx::serialization::serialize_buffer<float> a,
 
     // enqueue result read
     typedef hpx::serialization::serialize_buffer<float> buffer_type;
-    buffer_type result_buffer ( new float[size], size,
-                                buffer_type::init_mode::take );
+    buffer_type result_buffer ( size );
     auto read_event =
         hpxcl_single_buffer_z.enqueue_read( 0, result_buffer,
                                             kernel_log_event );

--- a/examples/opencl/benchmark_vector/matrix_generators.hpp
+++ b/examples/opencl/benchmark_vector/matrix_generators.hpp
@@ -31,7 +31,7 @@ generate_input_matrix(size_t size)
 
     // allocate output matrix
     typedef hpx::serialization::serialize_buffer<float> buffer_type;
-    buffer_type ret( new float[size], size, buffer_type::init_mode::take );
+    buffer_type ret( size );
 
     // fill output matrix
     for(size_t i = 0; i < size; i++)
@@ -63,7 +63,7 @@ calculate_result( hpx::serialization::serialize_buffer<float> a,
 
     // allocate output matrix
     typedef hpx::serialization::serialize_buffer<float> buffer_type;
-    buffer_type res( new float[size], size, buffer_type::init_mode::take );
+    buffer_type res( size );
     for(size_t i = 0; i < size; i++)
     {
         res[i] = 0.0f;

--- a/opencl/server/buffer.hpp
+++ b/opencl/server/buffer.hpp
@@ -435,7 +435,7 @@ hpx::opencl::server::buffer::enqueue_read_to_userbuffer_remote(
     cl_command_queue command_queue = parent_device->get_read_command_queue();
 
     // create new target buffer
-    buffer_type data( new char[size], size, buffer_type::init_mode::take );
+    buffer_type data( size );
 
     // run the OpenCL-call
     err = clEnqueueReadBuffer( command_queue, device_mem, CL_FALSE, offset,
@@ -561,8 +561,7 @@ hpx::opencl::server::buffer::enqueue_read_to_userbuffer_rect_remote(
     // create new target buffer
     std::size_t dst_size = rect_properties.size_x * rect_properties.size_y
                            * rect_properties.size_z * sizeof(T);
-    buffer_type data( new char[dst_size], dst_size,
-                      buffer_type::init_mode::take );
+    buffer_type data( dst_size );
 
     // prepare arguments for OpenCL call
     std::size_t buffer_origin[] = { rect_properties.src_x * sizeof(T),

--- a/opencl/server/buffer_server.cpp
+++ b/opencl/server/buffer_server.cpp
@@ -131,7 +131,7 @@ buffer::enqueue_read( hpx::naming::id_type && event_gid,
     cl_command_queue command_queue = parent_device->get_read_command_queue();
 
     // create new target buffer
-    buffer_type data( new char[size], size, buffer_type::init_mode::take );
+    buffer_type data( size );
 
     // run the OpenCL-call
     err = clEnqueueReadBuffer( command_queue, device_mem, CL_FALSE, offset,
@@ -180,7 +180,7 @@ buffer::send_bruteforce( hpx::naming::id_type && dst,
     cl_command_queue command_queue = parent_device->get_read_command_queue();
 
     // create new target buffer
-    buffer_type data( new char[size], size, buffer_type::init_mode::take );
+    buffer_type data( size );
 
     // run the OpenCL-call
     err = clEnqueueReadBuffer( command_queue, device_mem, CL_FALSE, src_offset,
@@ -288,8 +288,7 @@ buffer::send_rect_bruteforce( hpx::naming::id_type && dst,
     // create new target buffer
     std::size_t dst_size = rect_properties.size_x * rect_properties.size_y
                            * rect_properties.size_z;
-    buffer_type data( new char[dst_size], dst_size,
-                      buffer_type::init_mode::take );
+    buffer_type data( dst_size );
 
     // prepare arguments for OpenCL call
     std::size_t buffer_origin[] = { rect_properties.src_x,

--- a/opencl/server/device_server.cpp
+++ b/opencl/server/device_server.cpp
@@ -153,10 +153,8 @@ device::get_device_info(cl_device_info info_type)
     cl_ensure(err, "clGetDeviceInfo()");
 
     // Retrieve
-    hpx::serialization::serialize_buffer<char> info( new char[param_size],
-                                            param_size,
-                                            hpx::serialization::serialize_buffer<char>::take);
-    err = clGetDeviceInfo(device_id, info_type, param_size, info.data(), 0);
+    hpx::serialization::serialize_buffer<char> info( param_size );
+    err = clGetDeviceInfo(device_id, info_type, info.size(), info.data(), 0);
     cl_ensure(err, "clGetDeviceInfo()");
 
     // Return
@@ -180,10 +178,8 @@ device::get_platform_info(cl_platform_info info_type)
     cl_ensure(err, "clGetPlatformInfo()");
 
     // Retrieve
-    hpx::serialization::serialize_buffer<char>
-    info( new char[param_size], param_size,
-          hpx::serialization::serialize_buffer<char>::take);
-    err = clGetPlatformInfo(platform_id, info_type, param_size, info.data(), 0);
+    hpx::serialization::serialize_buffer<char> info( param_size );
+    err = clGetPlatformInfo(platform_id, info_type, info.size(), info.data(), 0);
     cl_ensure(err, "clGetPlatformInfo()");
 
     // Return

--- a/opencl/server/program_server.cpp
+++ b/opencl/server/program_server.cpp
@@ -281,8 +281,7 @@ program::get_binary()
     }
 
     // get binary code
-    buffer_type binary( new char[binary_size], binary_size,
-                        buffer_type::init_mode::take );
+    buffer_type binary( binary_size );
     char* binary_ptr = binary.data();
     err = clGetProgramInfo( program_id, CL_PROGRAM_BINARIES,
                             sizeof(unsigned char*),

--- a/tests/performance/opencl/bandwith.cpp
+++ b/tests/performance/opencl/bandwith.cpp
@@ -68,8 +68,7 @@ static void run_opencl_local_test( hpx::opencl::device device )
     while(results.needs_more_testing())
     {
         // initialize the buffer
-        buffer_type buf ( new char[test_data.size()], test_data.size(),
-                          buffer_type::init_mode::take );
+        buffer_type buf ( test_data.size() );
         std::copy(test_data.data(), test_data.data()+test_data.size(), buf.data());
 
         cl_int err;
@@ -150,8 +149,7 @@ static void run_opencl_local_send_test( hpx::opencl::device device )
     while(results.needs_more_testing())
     {
         // initialize the buffer
-        buffer_type buf ( new char[test_data.size()], test_data.size(),
-                          buffer_type::init_mode::take );
+        buffer_type buf ( test_data.size() );
         std::copy(test_data.data(), test_data.data()+test_data.size(), buf.data());
 
         cl_int err;
@@ -330,10 +328,8 @@ static void run_hpxcl_read_write_test( hpx::opencl::device device )
     while(results.needs_more_testing())
     {
         // initialize the buffer
-        buffer_type read_buf ( new char[test_data.size()], test_data.size(),
-                               buffer_type::init_mode::take );
-        buffer_type write_buf ( new char[test_data.size()], test_data.size(),
-                                buffer_type::init_mode::take );
+        buffer_type read_buf ( test_data.size() );
+        buffer_type write_buf ( test_data.size() );
         std::copy( test_data.data(), test_data.data()+test_data.size(),
                    write_buf.data() );
 
@@ -433,8 +429,7 @@ static void cl_test(hpx::opencl::device local_device,
 
     // Generate random vector
     std::cerr << "Generating test data ..." << std::endl;
-    test_data = buffer_type ( new char[testdata_size], testdata_size,
-                              buffer_type::init_mode::take );
+    test_data = buffer_type ( testdata_size );
     std::cerr << "Test data generated." << std::endl;
     for(std::size_t i = 0; i < testdata_size; i++){
         test_data[i] = static_cast<char>(rand());

--- a/tests/performance/opencl/overhead.cpp
+++ b/tests/performance/opencl/overhead.cpp
@@ -129,10 +129,8 @@ static void wait_test( hpx::opencl::device device )
     while(results.needs_more_testing())
     {
         // initialize the buffer
-        buffer_type write_buf1 ( new char[test_data.size()], test_data.size(),
-                                 buffer_type::init_mode::take );
-        buffer_type write_buf2 ( new char[test_data.size()], test_data.size(),
-                                 buffer_type::init_mode::take );
+        buffer_type write_buf1 ( test_data.size() );
+        buffer_type write_buf2 ( test_data.size() );
         std::copy( test_data.data(), test_data.data()+test_data.size(),
                    write_buf1.data() );
         std::copy( test_data.data(), test_data.data()+test_data.size(),
@@ -194,8 +192,7 @@ static void write_test( hpx::opencl::device device , bool sync )
     while(results.needs_more_testing())
     {
         // initialize the buffer
-        buffer_type write_buf ( new char[test_data.size()], test_data.size(),
-                                buffer_type::init_mode::take );
+        buffer_type write_buf ( test_data.size() );
         std::copy( test_data.data(), test_data.data()+test_data.size(),
                    write_buf.data() );
 
@@ -264,8 +261,7 @@ static void read_test( hpx::opencl::device device , bool sync )
     while(results.needs_more_testing())
     {
         // initialize the buffer
-        buffer_type write_buf ( new char[test_data.size()], test_data.size(),
-                                buffer_type::init_mode::take );
+        buffer_type write_buf ( test_data.size() );
         std::copy( test_data.data(), test_data.data()+test_data.size(),
                    write_buf.data() );
 
@@ -329,8 +325,7 @@ static void cl_test(hpx::opencl::device local_device,
 
     // Generate random vector
     std::cerr << "Generating test data ..." << std::endl;
-    test_data = buffer_type ( new char[testdata_size], testdata_size,
-                              buffer_type::init_mode::take );
+    test_data = buffer_type ( testdata_size );
     std::cerr << "Test data generated." << std::endl;
     for(std::size_t i = 0; i < testdata_size; i++){
         test_data[i] = static_cast<char>(rand());

--- a/tests/unit/opencl/buffer_read_write.cpp
+++ b/tests/unit/opencl/buffer_read_write.cpp
@@ -106,8 +106,7 @@ static void cl_test( hpx::opencl::device local_device,
 
     // test read to buffer
     {
-        intbuffer_type readbuffer( new uint32_t[2], 2,
-                               intbuffer_type::init_mode::take );
+        intbuffer_type readbuffer( 2 );
 
         auto data_read_future = buffer.enqueue_read(1, readbuffer);
 


### PR DESCRIPTION
Passing in a range of memory when constructing a `serialize_buffer` with the
`take` action without a deleter expects the memory to be allocated with the
allocator.

All call sites where a `new T[]` has been passed with ownership transfer have
been converted to let serialize_buffer allocate the memory instead.
