### PR TITLE
Fix win64 build on MSVC with CUDA+OpenCL

### DIFF
--- a/cmake/FindNVRTC.cmake
+++ b/cmake/FindNVRTC.cmake
@@ -10,7 +10,7 @@
 ##############################################################################
 find_package(PkgConfig)
 
-find_library(CUDA_NVRTC_LIB libnvrtc nvrtc HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${LIBNVRTC_LIBRARY_DIR}" /usr/lib64 /usr/local/cuda/lib64)
+find_library(CUDA_NVRTC_LIB libnvrtc nvrtc HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${LIBNVRTC_LIBRARY_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}/lib/x64" /usr/lib64 /usr/local/cuda/lib64)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LibNVRTC DEFAULT_MSG CUDA_NVRTC_LIB)

--- a/cuda/buffer.hpp
+++ b/cuda/buffer.hpp
@@ -37,9 +37,9 @@ public:
 	 */
 
 	hpx::lcos::future<size_t> size() {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::buffer::size_action action_type;
-		return hpx::async<action_type>(this->get_gid());
+		return hpx::async<action_type>(this->get_id());
 
 	}
 
@@ -57,9 +57,9 @@ public:
 	 */
 
 	hpx::lcos::future<void> set_size(size_t size) {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::buffer::set_size_action action_type;
-		return hpx::async<action_type>(this->get_gid(), size);
+		return hpx::async<action_type>(this->get_id(), size);
 
 	}
 
@@ -102,10 +102,10 @@ public:
 
 	hpx::future<hpx::serialization::serialize_buffer<char>> enqueue_read(
 			size_t offset, size_t size) {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 
 		typedef server::buffer::enqueue_read_action action_type;
-		return hpx::async<action_type>(this->get_gid(), offset, size);
+		return hpx::async<action_type>(this->get_id(), offset, size);
 
 	}
 
@@ -119,10 +119,10 @@ public:
 	 */
 
 	hpx::future<uintptr_t> enqueue_read_local(size_t offset, size_t size) {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 
 		typedef server::buffer::enqueue_read_local_action action_type;
-		return hpx::async<action_type>(this->get_gid(), offset, size);
+		return hpx::async<action_type>(this->get_id(), offset, size);
 
 	}
 
@@ -135,7 +135,7 @@ public:
 
 	hpx::future<void> enqueue_write(size_t offset, size_t size,
 			const void* data) const {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 
 		if (is_local) {
 
@@ -150,7 +150,7 @@ public:
 					hpx::serialization::serialize_buffer<char>::init_mode::reference);
 
 			typedef server::buffer::enqueue_write_action action_type;
-			return hpx::async<action_type>(this->get_gid(), offset, size,
+			return hpx::async<action_type>(this->get_id(), offset, size,
 					serializable_data);
 		}
 

--- a/cuda/device.hpp
+++ b/cuda/device.hpp
@@ -37,9 +37,9 @@ public:
 	 * \brief Method prints the properties of this device
 	 */
 	void get_cuda_info() {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::device::get_cuda_info_action action_type;
-		hpx::apply<action_type>(this->get_gid());
+		hpx::apply<action_type>(this->get_id());
 	}
 
 	/**
@@ -48,9 +48,9 @@ public:
 	 * \note All information of the cudaDeviceproperties are shown.
 	 */
 	void get_extended_cuda_info() {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::device::get_extended_cuda_info_action action_type;
-		hpx::apply<action_type>(this->get_gid());
+		hpx::apply<action_type>(this->get_id());
 	}
 
 	/**
@@ -58,9 +58,9 @@ public:
 	 * \return Major compute capability of this device
 	 */
 	hpx::lcos::future<int> get_device_architecture_major() {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::device::get_device_architecture_major_action action_type;
-		return hpx::async<action_type>(this->get_gid());
+		return hpx::async<action_type>(this->get_id());
 	}
 
 	/**
@@ -68,9 +68,9 @@ public:
 	 * \return Minor compute capability of this device
 	 */
 	hpx::lcos::future<int> get_device_architecture_minor() {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::device::get_device_architecture_minor_action action_type;
-		return hpx::async<action_type>(this->get_gid());
+		return hpx::async<action_type>(this->get_id());
 	}
 
 	/**
@@ -93,26 +93,26 @@ public:
 	}
 
 	void set_device(int dev) {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::device::set_device_action action_type;
-		hpx::async<action_type>(this->get_gid(), dev);
+		hpx::async<action_type>(this->get_id(), dev);
 	}
 
 	hpx::lcos::future<int> get_device_id() {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::device::get_device_id_action action_type;
-		return hpx::async<action_type>(this->get_gid());
+		return hpx::async<action_type>(this->get_id());
 	}
 
 	int get_device_id_sync() {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		return get_device_id().get();
 	}
 
 	hpx::lcos::future<int> get_context() {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::device::get_context_action action_type;
-		return hpx::async<action_type>(this->get_gid());
+		return hpx::async<action_type>(this->get_id());
 	}
 
 	int get_context_sync() {
@@ -144,9 +144,9 @@ public:
 	 */
 	hpx::cuda::program create_program_with_source(
 			std::string source) {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::device::create_program_with_source_action action_type;
-		return hpx::async<action_type>(this->get_gid(), source);
+		return hpx::async<action_type>(this->get_id(), source);
 	}
 
 	/**
@@ -162,7 +162,7 @@ public:
 	 */
 	hpx::cuda::program create_program_with_file(
 			std::string file) {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 
 		std::string source;
 		std::string tmp;
@@ -183,7 +183,7 @@ public:
 		}
 
 		typedef server::device::create_program_with_source_action action_type;
-		return hpx::async<action_type>(this->get_gid(), source);
+		return hpx::async<action_type>(this->get_id(), source);
 	}
 
 	/**
@@ -197,16 +197,16 @@ public:
 	 * \return The buffer with the allocated memoery on this device
 	 */
 	hpx::cuda::buffer create_buffer(size_t size) {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::device::create_buffer_action action_type;
-		return hpx::async<action_type>(this->get_gid(), size);
+		return hpx::async<action_type>(this->get_id(), size);
 	}
 
 	/**
 	 * \brief Synchronous creation of the buffer
 	 */
 	//hpx::cuda::buffer create_buffer_sync(size_t size) {
-		//HPX_ASSERT(this->get_gid());
+		//HPX_ASSERT(this->get_id());
 	//	return create_buffer(size).get();
 	//}
 };

--- a/cuda/program.hpp
+++ b/cuda/program.hpp
@@ -56,9 +56,9 @@ public:
 
 	hpx::lcos::future<void> build(std::vector<std::string> compilerFlags,
 			std::vector<std::string> modulenames, unsigned int debug = 0) {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::program::build_action action_type;
-		return hpx::async<action_type>(this->get_gid(), compilerFlags,
+		return hpx::async<action_type>(this->get_id(), compilerFlags,
 				modulenames, debug);
 	}
 
@@ -75,11 +75,11 @@ public:
 
 	hpx::lcos::future<void> build(std::vector<std::string> compilerFlags,
 			std::string modulename, unsigned int debug = 0) {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		std::vector<std::string> modulenames;
 		modulenames.push_back(modulename);
 		typedef server::program::build_action action_type;
-		return hpx::async<action_type>(this->get_gid(), compilerFlags,
+		return hpx::async<action_type>(this->get_id(), compilerFlags,
 				modulenames, debug);
 	}
 
@@ -96,9 +96,9 @@ public:
 	 * \brief Synchronous setting source code
 	 */
 	void set_source_sync(std::string source) {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::program::set_source_action action_type;
-		hpx::async<action_type>(this->get_gid(), source).get();
+		hpx::async<action_type>(this->get_id(), source).get();
 	}
 
 	/**
@@ -120,7 +120,7 @@ public:
 			std::string modulename, hpx::cuda::server::program::Dim3 grid,
 			hpx::cuda::server::program::Dim3 block, int stream = -1) {
 
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 
 		std::vector<hpx::naming::id_type> args_id;
 
@@ -132,7 +132,7 @@ public:
 		std::vector<hpx::naming::id_type> dependencies;
 
 		typedef server::program::run_action action_type;
-		return hpx::async<action_type>(this->get_gid(), args_id, modulename,
+		return hpx::async<action_type>(this->get_id(), args_id, modulename,
 				grid, block, dependencies, stream);
 
 	}
@@ -157,7 +157,7 @@ public:
 			hpx::cuda::server::program::Dim3 block,
 			std::vector<hpx::cuda::buffer> dependencies, int stream = -1) {
 
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 
 		std::vector<hpx::naming::id_type> args_id;
 
@@ -174,7 +174,7 @@ public:
 		}
 
 		typedef server::program::run_action action_type;
-		return hpx::async<action_type>(this->get_gid(), args_id, modulename,
+		return hpx::async<action_type>(this->get_id(), args_id, modulename,
 				grid, block, dependencies_id, stream);
 
 	}
@@ -184,7 +184,7 @@ public:
 			hpx::cuda::server::program::Dim3 block,
 			hpx::cuda::buffer dependency, int stream = -1) {
 
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 
 		std::vector<hpx::naming::id_type> args_id;
 
@@ -197,7 +197,7 @@ public:
 		dependencies_id.push_back(dependency.get_id());
 
 		typedef server::program::run_action action_type;
-		return hpx::async<action_type>(this->get_gid(), args_id, modulename,
+		return hpx::async<action_type>(this->get_id(), args_id, modulename,
 				grid, block, dependencies_id, stream);
 
 	}
@@ -210,9 +210,9 @@ public:
 	 */
 
 	hpx::lcos::future<unsigned int> get_streams_size() {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::program::get_streams_size_action action_type;
-		return hpx::async<action_type>(this->get_gid());
+		return hpx::async<action_type>(this->get_id());
 
 	}
 
@@ -224,9 +224,9 @@ public:
 	 */
 
 	hpx::lcos::future<unsigned int> create_stream() {
-		HPX_ASSERT(this->get_gid());
+		HPX_ASSERT(this->get_id());
 		typedef server::program::create_stream_action action_type;
-		return hpx::async<action_type>(this->get_gid());
+		return hpx::async<action_type>(this->get_id());
 	}
 
 };

--- a/cuda/server/program_server.cpp
+++ b/cuda/server/program_server.cpp
@@ -11,8 +11,10 @@
 #include "cuda/server/program.hpp"
 #include "cuda/server/buffer.hpp"
 
+#include <ciso646>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace hpx {
 namespace cuda {
@@ -74,15 +76,15 @@ void program::build(std::vector<std::string> compilerFlags,
 	nvrtcCreateProgram(&prog, this->kernel_source.c_str(), filename.c_str(), 0,
 			NULL, NULL);
 	checkCudaError("program::build Create Program");
-	const char * opts[compilerFlags.size()];
+  std::vector<const char*> opts(compilerFlags.size());
 	unsigned int i = 0;
 	for (auto opt : compilerFlags) {
 		opts[i] = compilerFlags[i].c_str();
 		i++;
 	}
 
-	nvrtcResult compileResult = nvrtcCompileProgram(prog, compilerFlags.size(),
-			opts);
+	nvrtcResult compileResult = nvrtcCompileProgram(prog, (int)compilerFlags.size(),
+			opts.data());
 
 	if (compileResult != NVRTC_SUCCESS) {
 		size_t logSize;
@@ -204,7 +206,7 @@ void program::run(std::vector<hpx::naming::id_type> args,
 }
 
 unsigned int program::get_streams_size() {
-	return this->streams.size();
+	return (int)this->streams.size();
 }
 
 unsigned int program::create_stream() {
@@ -214,7 +216,7 @@ unsigned int program::create_stream() {
 	cudaStreamCreate(&stream);
 	checkCudaError("program::program Error in creating default stream");
 	this->streams.push_back(stream);
-	return this->streams.size() - 1;
+	return (int)this->streams.size() - 1;
 }
 
 }

--- a/examples/cuda/build_kernel.cpp
+++ b/examples/cuda/build_kernel.cpp
@@ -10,8 +10,6 @@
 
 #include <hpxcl/cuda.hpp>
 
-#include <unistd.h>
-
 //#define DEBUG
 #define SIZE 1000
 

--- a/examples/cuda/build_kernel_from_file.cpp
+++ b/examples/cuda/build_kernel_from_file.cpp
@@ -10,8 +10,6 @@
 
 #include <hpxcl/cuda.hpp>
 
-#include <unistd.h>
-
 #define SIZE 100000
 
 using namespace hpx::cuda;

--- a/opencl/lcos/event.hpp
+++ b/opencl/lcos/event.hpp
@@ -90,6 +90,11 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
     public:
         event_data() {}
 
+        event_data(init_no_addref no_addref)
+          : parent_type(no_addref)
+        {
+        }
+
         ~event_data()
         {
             HPX_ASSERT(device_id && event_id);
@@ -136,6 +141,12 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
     public:
         event_data()
          : is_armed(false)
+        {
+        }
+
+        event_data(init_no_addref no_addref)
+         : is_armed(false)
+         , parent_type(no_addref)
         {
         }
 

--- a/tests/unit/opencl/dynamic_overloads.cpp
+++ b/tests/unit/opencl/dynamic_overloads.cpp
@@ -30,7 +30,7 @@ class test_client{
 hpx::future<int>
 test_client::func_impl( int && a, int && b,
                         hpx::opencl::util::resolved_events && ids){
-    return hpx::make_ready_future<int>(ids.event_ids.size() + 1000 * a + 100 * b);
+    return hpx::make_ready_future<int>((int)ids.event_ids.size() + 1000 * a + 100 * b);
 };
 
 static void cl_test( hpx::opencl::device local_device, 


### PR DESCRIPTION
This pull request addresses all the problems I can see on Windows 10 + Visual Studio 2015 Win64 with the CUDA 8.0 SDK.

It renames all uses of HPX `get_gid` into `get_id` which seems to be a replacement, and it honors the internal protocol of `init_no_addref` in HPX `promise_base`.

It also gets rid of some annoying warnings and spurious use of `<unistd.h>` in tests.

This ought to resolve #38.