### PR TITLE
Add typedef for base init_no_addref

### DIFF
--- a/opencl/lcos/event.hpp
+++ b/opencl/lcos/event.hpp
@@ -88,6 +88,8 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
         typedef typename parent_type::result_type result_type;
 
     public:
+        typedef typename parent_type::init_no_addref init_no_addref;
+
         event_data() {}
 
         event_data(init_no_addref no_addref)
@@ -139,6 +141,8 @@ namespace hpx { namespace opencl { namespace lcos { namespace detail
         typedef parent_type::result_type result_type;
 
     public:
+        typedef typename parent_type::init_no_addref init_no_addref;
+
         event_data()
          : is_armed(false)
         {


### PR DESCRIPTION
Conformant compilers cannot find types in dependent bases resulting in a
compiler error when using `init_no_addref` in `event_data`. Add a public
typedef to be standard compliant.

Verified this change by building all on Ubuntu 16.10 (GCC 6.2) and VS 2015.
This should address the problems surfaced post-merge in #40.