### PR TITLE
Update headers

### DIFF
--- a/cuda/server/device_server.cpp
+++ b/cuda/server/device_server.cpp
@@ -4,7 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
 #include <hpx/hpx.hpp>
-#include <hpx/util/io_service_pool.hpp>
+#include <hpx/modules/io_service.hpp> 
 
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/examples/cuda/build_kernel.cpp
+++ b/examples/cuda/build_kernel.cpp
@@ -4,8 +4,8 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/iostream.hpp>
+#include <hpx/future.hpp>
 
 #include <hpxcl/cuda.hpp>
 

--- a/examples/cuda/build_kernel_from_file.cpp
+++ b/examples/cuda/build_kernel_from_file.cpp
@@ -4,8 +4,8 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/iostream.hpp>
+#include <hpx/future.hpp>
 
 #include <hpxcl/cuda.hpp>
 

--- a/examples/cuda/cuda_list_devices.cpp
+++ b/examples/cuda/cuda_list_devices.cpp
@@ -3,8 +3,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/include/iostreams.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/iostream.hpp>
+#include <hpx/future.hpp>
 #include <hpx/hpx_main.hpp>
 
 #include <hpxcl/cuda.hpp>

--- a/examples/cuda/cuda_list_extended_devices.cpp
+++ b/examples/cuda/cuda_list_extended_devices.cpp
@@ -3,8 +3,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/include/iostreams.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/iostream.hpp>
+#include <hpx/future.hpp>
 #include <hpx/hpx_main.hpp>
 
 #include <hpxcl/cuda.hpp>

--- a/examples/cuda/streams.cpp
+++ b/examples/cuda/streams.cpp
@@ -4,8 +4,8 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/iostream.hpp>
+#include <hpx/future.hpp>
 
 #include "examples/opencl/benchmark_vector/timer.hpp"
 


### PR DESCRIPTION
Remove some deprecated header to prepare for the HPX 1.6.0 release.