### PR TITLE
Added function to get the buffer device ID and an example

### DIFF
--- a/cuda/buffer.cpp
+++ b/cuda/buffer.cpp
@@ -1,5 +1,6 @@
 // Copyright (c)    2013 Damond Howard
 //                  2015 Patrick Diehl
+//                  2021 Pedro Barbosa
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
@@ -36,3 +37,6 @@ HPX_REGISTER_ACTION(
 HPX_REGISTER_ACTION(
     cuda_buffer_type::wrapped_type::get_smart_pointer_action,
     cuda_buffer_get_smart_pointer_action);
+HPX_REGISTER_ACTION(
+    cuda_buffer_type::wrapped_type::get_device_id_action,
+    cuda_buffer_get_device_id_action);

--- a/cuda/buffer.hpp
+++ b/cuda/buffer.hpp
@@ -1,6 +1,7 @@
 // Copyright (c)    2013 Damond Howard
 //                  2015 Patrick Diehl
 //					2017 Madhavan Seshadri
+//					2021 Pedro Barbosa
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 #pragma once
@@ -127,6 +128,26 @@ public:
 
     }
 
+    /**
+	 * \brief Method to access the buffer's device ID
+	 * \return The ID of the device where the buffer is allocated
+	 */
+    hpx::lcos::future<int> get_device_id(){
+    
+		HPX_ASSERT(this->get_id());
+        
+        typedef server::buffer::get_device_id_action action_type;
+        return hpx::async<action_type>(this->get_id()); 
+    }
+    
+    /**
+	 * \brief Method to access the buffer's device ID
+	 * \return The ID of the device where the buffer is allocated
+	 */
+    int get_device_id_sync(){
+    	return get_device_id().get();
+    }
+    
 	/**
 	 * \brief Method copy the data on the attached device to the host
 	 * \param offset Offset, where to start copying data

--- a/cuda/server/buffer.hpp
+++ b/cuda/server/buffer.hpp
@@ -1,6 +1,7 @@
-// Copyright (c)		2013 Damond Howard
-//						2015 Patrick Diehl
-//                      2017 Madhavan Seshadri
+// Copyright (c)     2013 Damond Howard
+//                   2015 Patrick Diehl
+//                   2017 Madhavan Seshadri
+//                   2021 Pedro Barbosa
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
@@ -62,6 +63,8 @@ namespace hpx
 
                 void* get_raw_pointer();
 
+                int get_device_id();
+
                 std::shared_ptr<size_t> get_smart_pointer();
 
                 #ifdef HPXCL_CUDA_WITH_STREAMS
@@ -75,6 +78,7 @@ namespace hpx
                 HPX_DEFINE_COMPONENT_ACTION(buffer, enqueue_write);
                 HPX_DEFINE_COMPONENT_ACTION(buffer, enqueue_write_local);
                 HPX_DEFINE_COMPONENT_ACTION(buffer, get_smart_pointer);
+                HPX_DEFINE_COMPONENT_ACTION(buffer, get_device_id);
             };
         }
     }
@@ -101,4 +105,7 @@ namespace hpx
  HPX_REGISTER_ACTION_DECLARATION(
     hpx::cuda::server::buffer::get_smart_pointer_action,
     buffer_get_smart_pointer_action);
+ HPX_REGISTER_ACTION_DECLARATION(
+    hpx::cuda::server::buffer::get_device_id_action,
+    buffer_get_device_id_action);
  #endif //BUFFER_2_HPP

--- a/cuda/server/buffer_server.cpp
+++ b/cuda/server/buffer_server.cpp
@@ -1,6 +1,7 @@
 // Copyright (c)		2013 Damond Howard
 //						2015 Patrick Diehl
 //						2017 Madhavan Seshadri
+//						2021 Pedro Barbosa
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
@@ -140,7 +141,6 @@ void* buffer::get_raw_pointer() {
 	return &data_device;
 }
 
-
 /**
  * Get the device pointer wrapped in a smart pointer to make it seriazible
  */
@@ -148,6 +148,13 @@ void* buffer::get_raw_pointer() {
 std::shared_ptr<size_t> buffer::get_smart_pointer(){
 
     return std::shared_ptr<size_t>(reinterpret_cast<size_t*>(&data_device));
+}
+
+/**
+ * Get the device id
+ */
+int buffer::get_device_id(){
+	return this->parent_device_num;
 }
 
 void buffer::enqueue_write_local(size_t offset, size_t size, uintptr_t data) {

--- a/examples/cuda/CMakeLists.txt
+++ b/examples/cuda/CMakeLists.txt
@@ -11,6 +11,7 @@ set(example_programs
     build_kernel_from_file
     streams
     shared_memory
+    get_device_id
 )
 
 foreach(example_program ${example_programs})

--- a/examples/cuda/get_device_id.cpp
+++ b/examples/cuda/get_device_id.cpp
@@ -1,0 +1,49 @@
+// Copyright (c)       2021 Pedro Barbosa
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/iostream.hpp>
+#include <hpx/future.hpp>
+
+#include <hpxcl/cuda.hpp>
+
+using namespace hpx::cuda;
+
+int main(int argc, char* argv[]) {
+
+	// Get list of available Cuda Devices.
+	std::vector<device> devices = get_all_devices(2, 0).get();
+	
+	// Check whether there are any devices
+	if (devices.size() < 1) {
+		hpx::cerr << "No CUDA devices found!" << hpx::endl;
+		return hpx::finalize();
+	}
+
+	// Create a device component from the first device found
+	device cudaDevice_0 = devices[0];
+
+	// Create a buffer
+	buffer test_buffer_0 = cudaDevice_0.create_buffer(sizeof(int)).get();
+
+	// Get buffer parent id
+	int device_id_0 = test_buffer_0.get_device_id().get();
+	std::cout << device_id_0 << std::endl;
+
+	// Comment the following section in case there's only one device
+	// Create a device component from the second device found
+	device cudaDevice_1 = devices[1];
+	
+	// Create a buffer
+	buffer test_buffer_1 = cudaDevice_1.create_buffer(sizeof(int)).get();
+
+	// Get buffer parent id
+	int device_id_1 = test_buffer_1.get_device_id().get();
+	std::cout << device_id_1 << std::endl;
+
+	return EXIT_SUCCESS;
+}
+
+


### PR DESCRIPTION
A new function to access the buffer's parent device was added, as well as an example to test it.